### PR TITLE
Various fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+   # Maintain dependencies for GitHub Actions
+   - package-ecosystem: "github-actions"
+     directory: "/"
+     schedule:
+       interval: "monthly"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,21 +16,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - cabal: "3.8.1"
-            ghc: "8.8.4"
-            os: ubuntu-latest
-          - cabal: "3.8.1"
-            ghc: "8.10.7"
+          - cabal: "3.12"
+            ghc: "9.12.2"
+            os: ubuntu-22.04-arm
+          - cabal: "3.12"
+            ghc: "9.12.2"
             os: ubuntu-latest
           - cabal: "3.12"
             ghc: "9.10.1"
             os: ubuntu-latest
           - cabal: "3.12"
-            ghc: "9.12.1"
+            ghc: "9.6.7"
+            os: ubuntu-latest
+          - cabal: "3.4"
+            ghc: "9.0.2"
             os: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - uses: haskell-actions/setup@v2
@@ -42,9 +45,9 @@ jobs:
 
     - name: Freeze
       run: |
-        cabal configure
+        cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
         cabal freeze
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,18 +16,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - cabal: "3.2"
+          - cabal: "3.8.1"
+            ghc: "8.8.4"
+            os: ubuntu-latest
+          - cabal: "3.8.1"
             ghc: "8.10.7"
             os: ubuntu-latest
-          - cabal: "3.2"
-            ghc: "8.8.4"
+          - cabal: "3.12"
+            ghc: "9.10.1"
+            os: ubuntu-latest
+          - cabal: "3.12"
+            ghc: "9.12.1"
             os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -49,4 +55,4 @@ jobs:
         cabal build all
     - name: Test
       run: |
-        cabal test zebra-core
+        cabal test all

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cabal-dev
 cabal.sandbox.config
 tmp
 gen
+/dist-newstyle/

--- a/cabal.project
+++ b/cabal.project
@@ -11,43 +11,43 @@ constraints:
 source-repository-package
     type: git
     location: https://github.com/icicle-lang/viking.git
-    tag: 894a57086b39be059bf039418346751cd60ee1d7
+    tag: c3a273266c232212ad8d89db125282d03b5297a1
 
 source-repository-package
     type: git
     location: https://github.com/icicle-lang/anemone.git
-    tag: 95eae0bbadfa9f3b6a4886b0b9756c675f815244
+    tag: 2123aeb42d5b87b4a283354782a34328a2ef44a2
 
 source-repository-package
     type: git
     location: https://github.com/icicle-lang/snapper.git
-    tag: f9a3c3fcccac8d3e884991f5b122e0f368a69a8b
+    tag: 3bea7e3ca523bd855c5f64b1238c6e5c6685a362
 
 source-repository-package
     type: git
     location: https://github.com/icicle-lang/p.git
-    tag: a8e1a45de1296e820cb4869e1e087ee6c8a0e7a8
+    tag: 7482cc51b2e603ec48a8fa0ba43d3d820500ecbb
 
 source-repository-package
     type: git
-    location: https://github.com/icicle-lang/x.git
-    tag: 4b54bf1680e7683a2091fa2e9aa6153994625da7
+    location: https://github.com/tmcgilchrist/x.git
+    tag: ce516dc273a8ab44c8dea0ab0d1de835276b07e0
     subdir: x-show
 
 source-repository-package
     type: git
-    location: https://github.com/icicle-lang/x.git
-    tag: 4b54bf1680e7683a2091fa2e9aa6153994625da7
+    location: https://github.com/tmcgilchrist/x.git
+    tag: ce516dc273a8ab44c8dea0ab0d1de835276b07e0
     subdir: x-bytestring
 
 source-repository-package
     type: git
-    location: https://github.com/icicle-lang/x.git
-    tag: 4b54bf1680e7683a2091fa2e9aa6153994625da7
+    location: https://github.com/tmcgilchrist/x.git
+    tag: ce516dc273a8ab44c8dea0ab0d1de835276b07e0
     subdir: x-optparse
 
 source-repository-package
     type: git
-    location: https://github.com/icicle-lang/x.git
-    tag: 4b54bf1680e7683a2091fa2e9aa6153994625da7
+    location: https://github.com/tmcgilchrist/x.git
+    tag: ce516dc273a8ab44c8dea0ab0d1de835276b07e0
     subdir: x-vector

--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/icicle-lang/anemone.git
-    tag: 2123aeb42d5b87b4a283354782a34328a2ef44a2
+    tag: 59fa938366193f672a1b02159eef94c06c7bb748
 
 source-repository-package
     type: git
@@ -26,28 +26,28 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/icicle-lang/p.git
-    tag: 7482cc51b2e603ec48a8fa0ba43d3d820500ecbb
+    tag: 617e5dc2887f3e99d67b29c799fa406f106fdbc6
 
 source-repository-package
     type: git
-    location: https://github.com/tmcgilchrist/x.git
-    tag: ce516dc273a8ab44c8dea0ab0d1de835276b07e0
+    location: https://github.com/icicle-lang/x.git
+    tag: 7c9dc0ac182c84980d73345fc65ca5282090b720
     subdir: x-show
 
 source-repository-package
     type: git
-    location: https://github.com/tmcgilchrist/x.git
-    tag: ce516dc273a8ab44c8dea0ab0d1de835276b07e0
+    location: https://github.com/icicle-lang/x.git
+    tag: 7c9dc0ac182c84980d73345fc65ca5282090b720
     subdir: x-bytestring
 
 source-repository-package
     type: git
-    location: https://github.com/tmcgilchrist/x.git
-    tag: ce516dc273a8ab44c8dea0ab0d1de835276b07e0
+    location: https://github.com/icicle-lang/x.git
+    tag: 7c9dc0ac182c84980d73345fc65ca5282090b720
     subdir: x-optparse
 
 source-repository-package
     type: git
-    location: https://github.com/tmcgilchrist/x.git
-    tag: ce516dc273a8ab44c8dea0ab0d1de835276b07e0
+    location: https://github.com/icicle-lang/x.git
+    tag: 7c9dc0ac182c84980d73345fc65ca5282090b720
     subdir: x-vector

--- a/zebra-cli/ambiata-zebra-cli.cabal
+++ b/zebra-cli/ambiata-zebra-cli.cabal
@@ -28,17 +28,17 @@ library
                     , ambiata-zebra-core
                     , binary                          >= 0.7.2      && < 0.9
                     , bytestring                      >= 0.10
-                    , containers                      == 0.5.*
+                    , containers                      >=0.5         && < 0.7
                     , exceptions                      >= 0.10
                     , mmorph                          >= 1.0
-                    , pretty-show                     == 1.6.*
+                    , pretty-show                     == 1.10.*
                     , resourcet                       >= 1.1
                     , semigroups                      >= 0.18
-                    , text                            == 1.2.*
-                    , transformers                    == 0.5.*
+                    , text                            >= 2.0        && < 2.2
+                    , transformers                    >=0.5         && < 0.7
                     , transformers-either
                     , concurrent-output               >= 1.6        && < 1.11
-                    , vector                          >= 0.11       && < 0.13
+                    , vector                          >= 0.11       && < 0.14
 
   ghc-options:
                     -Wall

--- a/zebra-core/ambiata-zebra-core.cabal
+++ b/zebra-core/ambiata-zebra-core.cabal
@@ -28,34 +28,35 @@ library
                     , ambiata-x-bytestring
                     , ambiata-x-show
                     , ambiata-x-vector
-                    , aeson                           >= 1.0        && < 1.5
+                    , aeson                           >= 2.0        && < 2.3
+                    , attoparsec-aeson
                     , aeson-pretty                    == 0.8.*
-                    , attoparsec                      >= 0.13       && < 0.14
-                    , base64-bytestring               == 1.0.*
-                    , bifunctors                      >= 4.2        && < 5.6
+                    , attoparsec                      >= 0.13       && < 0.15
+                    , base64-bytestring               >= 1.0        && < 1.3
+                    , bifunctors                      >= 4.2        && < 5.7
                     , binary                          >= 0.7.2      && < 0.9
                     , bindings-DSL                    >= 1.0.0      && <= 1.0.26
                     , bytestring                      >= 0.1
                     , containers                      >= 0.5
                     , exceptions                      >= 0.10       && < 0.11
-                    , ghc-prim                        >= 0.4        && < 0.7
+                    , ghc-prim                        >= 0.4        && < 0.14
                     , lens                            >= 4.7
                     , mmorph                          >= 1.1
                     , mtl                             >= 2.2
                     , old-locale                      == 1.0.*
-                    , pretty-show                     == 1.6.*
+                    , pretty-show                     == 1.10.*
                     , primitive                       >= 0.6
-                    , random                          == 1.1.*
+                    , random                          >= 1.1        && < 1.4
                     , resourcet                       >= 1.2
                     , semigroups                      >= 0.18
                     , streaming                       >= 0.1        && < 0.3
-                    , streaming-bytestring            >= 0.1        && < 0.3
-                    , text                            == 1.2.*
+                    , streaming-bytestring            >= 0.1        && < 0.4
+                    , text                            >= 2.0        && < 2.2
                     , thyme                           >= 0.4        && < 0.5
-                    , transformers                    == 0.5.*
+                    , transformers                    == 0.6.*
                     , transformers-either
                     , unordered-containers            == 0.2.*
-                    , vector                          >= 0.11       && < 0.13
+                    , vector                          >= 0.11       && < 0.14
                     , vector-th-unbox                 == 0.2.*
 
   ghc-options:

--- a/zebra-core/ambiata-zebra-core.cabal
+++ b/zebra-core/ambiata-zebra-core.cabal
@@ -161,7 +161,7 @@ library
                        csrc/zebra_unpack.c
 
   cc-options:
-                       -std=c99 -ggdb -msse4.2 -Wall -Werror -Wuninitialized -Wno-unused-command-line-argument -DCABAL=1
+                       -std=c99 -Wall -Werror -Wuninitialized -Wno-unused-command-line-argument -DCABAL=1
 
 test-suite test
   type:

--- a/zebra-core/src/Zebra/Serial/Binary/Array.hs
+++ b/zebra-core/src/Zebra/Serial/Binary/Array.hs
@@ -91,7 +91,7 @@ bByteArray uncompressed =
 getByteArray :: Int -> Get ByteString
 getByteArray n_expected = do
   n_compressed <- Get.getWord32le
-  compressed   <- Get.getBytes $ fromIntegral n_compressed
+  compressed   <- Get.getByteString $ fromIntegral n_compressed
   case Snappy.decompress compressed of
     Nothing ->
       fail $
@@ -169,7 +169,7 @@ bIntArray xs =
       -- num-bits (len * 1 byte)
       -- packs worst case (len * 8 byte)
       ensure = 4 + 8 + len + len * 8
-      prim = Prim.boudedPrim ensure Foreign.packArray
+      prim = Prim.boundedPrim ensure Foreign.packArray
   in Prim.primBounded prim xs
 {-# INLINABLE bIntArray #-}
 
@@ -177,7 +177,7 @@ getIntArray :: Int -> Get (Storable.Vector Int64)
 getIntArray elems = do
   bufsize <- fromIntegral <$> Get.getWord32le
   offset  <- fromIntegral <$> Get.getWord64le
-  bytes   <- Get.getBytes bufsize
+  bytes   <- Get.getByteString bufsize
   case Foreign.unpackArray bytes elems offset of
     Left err -> fail $ "Could not unpack 64-encoded words: " <> show err
     Right xs -> pure xs

--- a/zebra-core/src/Zebra/Serial/Binary/Header.hs
+++ b/zebra-core/src/Zebra/Serial/Binary/Header.hs
@@ -157,7 +157,7 @@ bVersion = \case
 
 getVersion :: Get BinaryVersion
 getVersion = do
-  bs <- Get.getBytes $ ByteString.length MagicV2
+  bs <- Get.getByteString $ ByteString.length MagicV2
   case bs of
     MagicV0 ->
       fail "This version of zebra cannot read v0 zebra files."

--- a/zebra-core/src/Zebra/Serial/Binary/Table.hs
+++ b/zebra-core/src/Zebra/Serial/Binary/Table.hs
@@ -12,7 +12,6 @@ import qualified Data.Binary.Get as Get
 import           Data.ByteString (ByteString)
 import           Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as Build
-import           Data.Coerce (coerce)
 import qualified Data.Text as Text
 
 import           P
@@ -150,21 +149,21 @@ getColumn version n = \case
 {-# INLINABLE getColumn #-}
 
 bTagArray :: Storable.Vector Tag -> Builder
-bTagArray =
-  bIntArray . coerce
+bTagArray vt =
+  bIntArray . unsafeCoerce $ vt
 {-# INLINABLE bTagArray #-}
 
 getTagArray :: Int -> Get (Storable.Vector Tag)
 getTagArray n =
-  coerce <$> getIntArray n
+  unsafeCoerce <$> getIntArray n
 {-# INLINABLE getTagArray #-}
 
 bDoubleArray :: Storable.Vector Double -> Builder
 bDoubleArray =
-  bIntArray . coerce
+  bIntArray . unsafeCoerce
 {-# INLINABLE bDoubleArray #-}
 
 getDoubleArray :: Int -> Get (Storable.Vector Double)
 getDoubleArray n =
-  coerce <$> getIntArray n
+  unsafeCoerce <$> getIntArray n
 {-# INLINABLE getDoubleArray #-}

--- a/zebra-core/src/Zebra/Serial/Binary/Table.hs
+++ b/zebra-core/src/Zebra/Serial/Binary/Table.hs
@@ -150,20 +150,20 @@ getColumn version n = \case
 
 bTagArray :: Storable.Vector Tag -> Builder
 bTagArray vt =
-  bIntArray . unsafeCoerce $ vt
+  bIntArray . Storable.unsafeCoerceVector $ vt
 {-# INLINABLE bTagArray #-}
 
 getTagArray :: Int -> Get (Storable.Vector Tag)
 getTagArray n =
-  unsafeCoerce <$> getIntArray n
+  Storable.unsafeCoerceVector <$> getIntArray n
 {-# INLINABLE getTagArray #-}
 
 bDoubleArray :: Storable.Vector Double -> Builder
 bDoubleArray =
-  bIntArray . unsafeCoerce
+  bIntArray . Storable.unsafeCast
 {-# INLINABLE bDoubleArray #-}
 
 getDoubleArray :: Int -> Get (Storable.Vector Double)
 getDoubleArray n =
-  unsafeCoerce <$> getIntArray n
+  Storable.unsafeCast <$> getIntArray n
 {-# INLINABLE getDoubleArray #-}

--- a/zebra-core/src/Zebra/Table/Logical.hs
+++ b/zebra-core/src/Zebra/Table/Logical.hs
@@ -67,9 +67,8 @@ import qualified Data.Text as Text
 import qualified Data.Vector as Boxed
 
 import           GHC.Generics (Generic)
--- import           GHC.Prim (tagToEnum#)
-import           GHC.Magic ( DataToTag(..) )
-import           GHC.Base ((>#), tagToEnum#)
+import           GHC.Exts ( dataToTag#, (>#), tagToEnum#)
+
 import           P hiding (empty, some, length)
 
 import           Text.Show.Pretty (ppShow)
@@ -557,7 +556,7 @@ instance Ord Value where
         compareTag (Reversed x) y
   {-# INLINABLE compare #-}
 
-compareTag :: (GHC.Magic.DataToTag a) => a -> a -> Ordering
+compareTag :: Value -> Value -> Ordering
 compareTag x y =
   if tagToEnum# (dataToTag# x ># dataToTag# y) then
     GT

--- a/zebra-core/src/Zebra/Table/Logical.hs
+++ b/zebra-core/src/Zebra/Table/Logical.hs
@@ -67,8 +67,9 @@ import qualified Data.Text as Text
 import qualified Data.Vector as Boxed
 
 import           GHC.Generics (Generic)
-import           GHC.Prim ((>#), tagToEnum#, dataToTag#)
-
+-- import           GHC.Prim (tagToEnum#)
+import           GHC.Magic ( DataToTag(..) )
+import           GHC.Base ((>#), tagToEnum#)
 import           P hiding (empty, some, length)
 
 import           Text.Show.Pretty (ppShow)
@@ -556,7 +557,7 @@ instance Ord Value where
         compareTag (Reversed x) y
   {-# INLINABLE compare #-}
 
-compareTag :: a -> a -> Ordering
+compareTag :: (GHC.Magic.DataToTag a) => a -> a -> Ordering
 compareTag x y =
   if tagToEnum# (dataToTag# x ># dataToTag# y) then
     GT

--- a/zebra-core/src/Zebra/X/Vector/Generic.hs
+++ b/zebra-core/src/Zebra/X/Vector/Generic.hs
@@ -13,7 +13,7 @@ module Zebra.X.Vector.Generic (
 
 import           X.Data.Vector.Stream (Stream(..), Step(..))
 import qualified X.Data.Vector.Stream as Stream
-import           X.Data.Vector.Generic as Generic
+import           X.Data.Vector.Generic as Generic hiding (group)
 
 import           P hiding (concatMap, length, sum)
 


### PR DESCRIPTION
I'm using `unsafeCoerce` when it could be `coerce` but it needs a `Coercible a b` instance. I expected that would be supplied alongside the `newtype` but apparently not 🤷🏻 


```
src/Zebra/Serial/Binary/Table.hs:155:15: error: [GHC-18872]
    • Couldn't match type ‘Tag’ with ‘Int64’
        arising from a use of ‘coerce’
    • In the second argument of ‘(.)’, namely ‘coerce’
      In the first argument of ‘($)’, namely ‘bIntArray . coerce’
      In the expression: bIntArray . coerce $ vt
    |
155 |   bIntArray . coerce $ vt
    |               ^^^^^^

```